### PR TITLE
MemcachedSessionStore

### DIFF
--- a/examples/core/shared-sessions/README
+++ b/examples/core/shared-sessions/README
@@ -1,0 +1,4 @@
+A very simple demo.
+
+Run it like this:
+lighttpd -Df lighttpd.conf

--- a/examples/core/shared-sessions/lighttpd-spawnfcgi.conf
+++ b/examples/core/shared-sessions/lighttpd-spawnfcgi.conf
@@ -1,0 +1,24 @@
+include "../../lighttpd.conf"
+
+# Browsers insists on making a second request to favicon.ico simultaneously,
+# making it hard to control which of the two servers is being hit by the 
+# load balancer.
+
+$HTTP["url"] !~ "^/favicon.ico$" {
+  fastcgi.server = (
+    "/" => (
+      (
+				"host" => "127.0.0.1",
+				"port" => 5000,
+				"check-local" => "disable",
+				"allow-x-send-file" => "enable"
+      ),
+      (
+				"host" => "127.0.0.1",
+				"port" => 5001,
+				"check-local" => "disable",
+				"allow-x-send-file" => "enable"
+      )
+    )
+  )
+}

--- a/examples/core/shared-sessions/lighttpd.conf
+++ b/examples/core/shared-sessions/lighttpd.conf
@@ -1,0 +1,28 @@
+include "../../lighttpd.conf"
+
+# Browsers insists on making a second request to favicon.ico simultaneously,
+# making it hard to control which of the two servers is being hit by the 
+# load balancer.
+
+$HTTP["url"] !~ "^/favicon.ico$" {
+  fastcgi.server = (
+    "/" => (
+      (
+        "socket" => var.CWD + "/smisk.sock.0",
+        "bin-path" => var.CWD + "/process.py",
+        "check-local" => "disable",
+        "bin-copy-environment" => ("PATH", "SHELL", "USER"),
+        "min-procs" => 1,
+        "max-procs" => 1
+      ),
+      (
+        "socket" => var.CWD + "/smisk.sock.1",
+        "bin-path" => var.CWD + "/process.py",
+        "check-local" => "disable",
+        "bin-copy-environment" => ("PATH", "SHELL", "USER"),
+        "min-procs" => 1,
+        "max-procs" => 1
+      )
+    ),
+  )
+}

--- a/examples/core/shared-sessions/process.py
+++ b/examples/core/shared-sessions/process.py
@@ -1,6 +1,8 @@
 #!/usr/local/bin/python2.5
 # encoding: utf-8
 from smisk.core import Application
+from smisk.core import FileSessionStore
+from smisk.core import MemcachedSessionStore
 from smisk.config import config
 import sys, os, socket
 from datetime import datetime
@@ -11,21 +13,24 @@ from smisk.util.main import daemonize, main
 class MyApp(Application):
   def __init__(self, *args, **kwargs):
 
-    self.sessions.ttl = 10
+    # self.sessions_class = FileSessionStore
+    self.sessions_class = MemcachedSessionStore
     self.sessions.memcached_config = "--SERVER=localhost:11211"
+
+    self.sessions.ttl = 10
+
 
   def service(self):
 
     if self.request.session == None:
       self.request.session = "this is my fabulous session content"
 
-
     path = self.request.url.path.strip('/')
     if path == 'clear':
       self.sessions.destroy(self.request.session_id)
 
-    val = config.get('smisk.memcached.configstring')
-    memcached = self.sessions.memcached_config
+    # val = config.get('smisk.memcached.configstring')
+    # memcached = self.sessions.memcached_config
 
     self.response.headers = ["Content-Type: text/plain"]
     self.response(
@@ -44,7 +49,14 @@ try:
   # config.load('shared-sessions.conf')
   # config('shared-sessions')
 
-  MyApp().run()
+  tempdir = "/tmp/smisk/smisk.%d" % os.getpid()
+  os.mkdir(tempdir)
+  tempfile.tempdir = tempdir
+
+  app = MyApp()
+
+
+  app.run()
 
 except KeyboardInterrupt:
   pass

--- a/examples/core/shared-sessions/process.py
+++ b/examples/core/shared-sessions/process.py
@@ -11,6 +11,7 @@ class MyApp(Application):
   def __init__(self, *args, **kwargs):
 
     self.sessions.ttl = 10
+    self.sessions.memcached_config = "--SERVER=localhost:11211"
 
   def service(self):
 
@@ -19,7 +20,7 @@ class MyApp(Application):
       self.request.session = os.getpid()
 
     val = config.get('smisk.memcached.configstring')
-    memcached = self.memcached
+    memcached = self.sessions.memcached_config
 
     self.response.headers = ["Content-Type: text/plain"]
     self.response(

--- a/examples/core/shared-sessions/process.py
+++ b/examples/core/shared-sessions/process.py
@@ -16,10 +16,8 @@ class MyApp(Application):
 
   def service(self):
 
-    #if self.request.session is False:
     if self.request.session == None:
-      # self.request.session = "coooolers: %d" % os.getpid()
-      self.request.session = "apan ola spelar boll"
+      self.request.session = "this is my fabulous session content"
 
     val = config.get('smisk.memcached.configstring')
     memcached = self.sessions.memcached_config
@@ -28,9 +26,7 @@ class MyApp(Application):
     self.response(
       "This comes from a separately running process.\n\n",
       "Host:          %s\n" % socket.getfqdn(),
-      "Config val:          %s\n" % memcached,
       "Process id:    %d\n" % os.getpid(),
-      "Process owner: %s\n" % os.getenv('USER'),
       "self.request.url: %r\n" % self.request.url,
       "self.request.env: %r\n" % self.request.env,
       "self.request.session: %r\n" % self.request.session,
@@ -39,6 +35,7 @@ class MyApp(Application):
 
 try:
 
+  # TODO: use config file to set sessions.ttl and sessions.memcached_config
   # config.load('shared-sessions.conf')
   # config('shared-sessions')
 

--- a/examples/core/shared-sessions/process.py
+++ b/examples/core/shared-sessions/process.py
@@ -1,6 +1,7 @@
 #!/usr/local/bin/python2.5
 # encoding: utf-8
 from smisk.core import Application
+from smisk.config import config
 import sys, os, socket
 from datetime import datetime
 from time import sleep
@@ -17,10 +18,14 @@ class MyApp(Application):
     if self.request.session == None:
       self.request.session = os.getpid()
 
+    val = config.get('smisk.memcached.configstring')
+    memcached = self.memcached
+
     self.response.headers = ["Content-Type: text/plain"]
     self.response(
       "This comes from a separately running process.\n\n",
       "Host:          %s\n" % socket.getfqdn(),
+      "Config val:          %s\n" % memcached,
       "Process id:    %d\n" % os.getpid(),
       "Process owner: %s\n" % os.getenv('USER'),
       "self.request.url: %r\n" % self.request.url,
@@ -37,6 +42,7 @@ try:
   os.mkdir(tempdir)
   tempfile.tempdir = tempdir
 
+  config.load('shared-sessions.conf')
   MyApp().run()
 
 except KeyboardInterrupt:

--- a/examples/core/shared-sessions/process.py
+++ b/examples/core/shared-sessions/process.py
@@ -6,6 +6,7 @@ import sys, os, socket
 from datetime import datetime
 from time import sleep
 import tempfile
+from smisk.util.main import daemonize, main
 
 class MyApp(Application):
   def __init__(self, *args, **kwargs):
@@ -17,7 +18,8 @@ class MyApp(Application):
 
     #if self.request.session is False:
     if self.request.session == None:
-      self.request.session = os.getpid()
+      # self.request.session = "coooolers: %d" % os.getpid()
+      self.request.session = "apan ola spelar boll"
 
     val = config.get('smisk.memcached.configstring')
     memcached = self.sessions.memcached_config
@@ -36,14 +38,10 @@ class MyApp(Application):
     )
 
 try:
-  # Simulate non-shared sessions for instances running on the same machine
-  # by appending PID to tmp path used by smisk_FileSessionStore_path
 
-  tempdir = "/tmp/smisk/smisk.%d" % os.getpid()
-  os.mkdir(tempdir)
-  tempfile.tempdir = tempdir
+  # config.load('shared-sessions.conf')
+  # config('shared-sessions')
 
-  config.load('shared-sessions.conf')
   MyApp().run()
 
 except KeyboardInterrupt:

--- a/examples/core/shared-sessions/process.py
+++ b/examples/core/shared-sessions/process.py
@@ -19,6 +19,11 @@ class MyApp(Application):
     if self.request.session == None:
       self.request.session = "this is my fabulous session content"
 
+
+    path = self.request.url.path.strip('/')
+    if path == 'clear':
+      self.sessions.destroy(self.request.session_id)
+
     val = config.get('smisk.memcached.configstring')
     memcached = self.sessions.memcached_config
 

--- a/examples/core/shared-sessions/process.py
+++ b/examples/core/shared-sessions/process.py
@@ -1,0 +1,43 @@
+#!/usr/local/bin/python2.5
+# encoding: utf-8
+from smisk.core import Application
+import sys, os, socket
+from datetime import datetime
+from time import sleep
+import tempfile
+
+class MyApp(Application):
+  def __init__(self, *args, **kwargs):
+
+    self.sessions.ttl = 10
+
+  def service(self):
+
+    #if self.request.session is False:
+    if self.request.session == None:
+      self.request.session = os.getpid()
+
+    self.response.headers = ["Content-Type: text/plain"]
+    self.response(
+      "This comes from a separately running process.\n\n",
+      "Host:          %s\n" % socket.getfqdn(),
+      "Process id:    %d\n" % os.getpid(),
+      "Process owner: %s\n" % os.getenv('USER'),
+      "self.request.url: %r\n" % self.request.url,
+      "self.request.env: %r\n" % self.request.env,
+      "self.request.session: %r\n" % self.request.session,
+      "self.request.session_id: %r\n" % self.request.session_id
+    )
+
+try:
+  # Simulate non-shared sessions for instances running on the same machine
+  # by appending PID to tmp path used by smisk_FileSessionStore_path
+
+  tempdir = "/tmp/smisk/smisk.%d" % os.getpid()
+  os.mkdir(tempdir)
+  tempfile.tempdir = tempdir
+
+  MyApp().run()
+
+except KeyboardInterrupt:
+  pass

--- a/examples/core/shared-sessions/shared-sessions.conf
+++ b/examples/core/shared-sessions/shared-sessions.conf
@@ -1,0 +1,1 @@
+"smisk.memcached.configstring": "--SERVER=localhost:11211"

--- a/examples/lighttpd.conf
+++ b/examples/lighttpd.conf
@@ -1,5 +1,5 @@
 # Basic setup
-server.port = 8080
+server.port = 8082
 server.tag = "lighttpd"
 server.use-ipv6 = "enable"
 server.document-root = var.CWD + "/"

--- a/gdb-hijack.sh
+++ b/gdb-hijack.sh
@@ -1,0 +1,1 @@
+gdb /usr/local/bin/python2.5 `ps ax| grep process.py | grep -v "grep" | cut -d " " -f 1`

--- a/lib/smisk/session.py
+++ b/lib/smisk/session.py
@@ -49,7 +49,7 @@ class Store:
     '''
     raise NotImplementedError
   
-  def refresh(self, session_id):
+  def refresh(self, session_id, data):
     '''
     Refresh session.
     
@@ -63,6 +63,8 @@ class Store:
     
     :param  session_id:  Session ID
     :type   session_id:  string
+    :param  data:        Data to be associated with ``session_id``
+    :type   data:        object
     :rtype: None
     '''
     raise NotImplementedError

--- a/memcached-test.sh
+++ b/memcached-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+S="--server=localhost:11211"
+
+echo "test" > file.txt
+
+echo "Setting with TTL=2 and waiting for 2 s..."
+memcp $S --set --expire 3 file.txt
+sleep 1 
+echo "add'ing in between"
+memcp $S --expire 3 --set file.txt
+sleep 2 
+echo "Checking key:"
+memcat $S file.txt
+
+echo "Setting with TTL=2 and waiting for 1 s..."
+memcp $S --set --expire 3 file.txt
+sleep 1
+echo "Checking key:"
+memcat $S file.txt

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ sources = [
   'src/URL.c',
   'src/SessionStore.c',
   'src/FileSessionStore.c',
+  'src/MemcachedSessionStore.c',
 
     'src/xml/__init__.c']
 
@@ -245,6 +246,7 @@ class build_ext(_build_ext):
       '/usr/local/lib'])
     
     self.libraries.append('fcgi')
+    self.libraries.append('memcached')
     self.define = [
       ('SMISK_VERSION', '"%s"' % version),
       ('SMISK_BUILD_ID', '"%s"' % core_build_id()),

--- a/src/Application.c
+++ b/src/Application.c
@@ -206,8 +206,7 @@ PyObject * smisk_Application_new(PyTypeObject *type, PyObject *args, PyObject *k
     // Set default classes
     self->request_class = (PyTypeObject*)&smisk_RequestType;
     self->response_class = (PyTypeObject*)&smisk_ResponseType;
-    /* self->sessions_class = (PyTypeObject*)&smisk_FileSessionStoreType;*/
-    self->sessions_class = (PyTypeObject*)&smisk_MemcachedSessionStoreType;
+    self->sessions_class = (PyTypeObject*)&smisk_FileSessionStoreType;
   
     // Set transaction context to None - run() will set up these.
     self->request = (smisk_Request *)Py_None; Py_INCREF(Py_None);

--- a/src/Application.c
+++ b/src/Application.c
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include "utils.h"
 #include "Application.h"
 #include "FileSessionStore.h"
+#include "MemcachedSessionStore.h"
 
 #include <fcgiapp.h>
 #include <fastcgi.h>
@@ -205,7 +206,8 @@ PyObject * smisk_Application_new(PyTypeObject *type, PyObject *args, PyObject *k
     // Set default classes
     self->request_class = (PyTypeObject*)&smisk_RequestType;
     self->response_class = (PyTypeObject*)&smisk_ResponseType;
-    self->sessions_class = (PyTypeObject*)&smisk_FileSessionStoreType;
+    /* self->sessions_class = (PyTypeObject*)&smisk_FileSessionStoreType;*/
+    self->sessions_class = (PyTypeObject*)&smisk_MemcachedSessionStoreType;
   
     // Set transaction context to None - run() will set up these.
     self->request = (smisk_Request *)Py_None; Py_INCREF(Py_None);
@@ -215,6 +217,7 @@ PyObject * smisk_Application_new(PyTypeObject *type, PyObject *args, PyObject *k
     self->sessions = NULL;
   
     // Default values
+    self->memcached = PyBytes_FromString("testing"); Py_INCREF(self->memcached);
     self->show_traceback = Py_True; Py_INCREF(Py_True);
     self->tolerant = Py_True; Py_INCREF(Py_True);
     self->forks = 0;
@@ -252,6 +255,7 @@ void smisk_Application_dealloc(smisk_Application *self) {
   Py_DECREF(self->response);
   Py_XDECREF(self->sessions);
   Py_DECREF(self->show_traceback);
+  Py_DECREF(self->memcached);
   Py_DECREF(self->tolerant);
   Py_DECREF(self->charset);
   
@@ -798,6 +802,7 @@ static struct PyMemberDef smisk_Application_members[] = {
   {"request", T_OBJECT_EX, offsetof(smisk_Application, request),  RO, ":type: Request"},
   {"response", T_OBJECT_EX, offsetof(smisk_Application, response), RO, ":type: Response"},
   {"show_traceback", T_OBJECT_EX, offsetof(smisk_Application, show_traceback), 0, ":type: bool"},
+  {"memcached", T_OBJECT_EX, offsetof(smisk_Application, memcached), 0, ":type: string"},
   {"forks", T_INT, offsetof(smisk_Application, forks), 0, ":type: int"},
   {NULL, 0, 0, 0, NULL}
 };

--- a/src/Application.c
+++ b/src/Application.c
@@ -217,7 +217,6 @@ PyObject * smisk_Application_new(PyTypeObject *type, PyObject *args, PyObject *k
     self->sessions = NULL;
   
     // Default values
-    self->memcached = PyBytes_FromString("testing"); Py_INCREF(self->memcached);
     self->show_traceback = Py_True; Py_INCREF(Py_True);
     self->tolerant = Py_True; Py_INCREF(Py_True);
     self->forks = 0;
@@ -255,7 +254,6 @@ void smisk_Application_dealloc(smisk_Application *self) {
   Py_DECREF(self->response);
   Py_XDECREF(self->sessions);
   Py_DECREF(self->show_traceback);
-  Py_DECREF(self->memcached);
   Py_DECREF(self->tolerant);
   Py_DECREF(self->charset);
   
@@ -802,7 +800,6 @@ static struct PyMemberDef smisk_Application_members[] = {
   {"request", T_OBJECT_EX, offsetof(smisk_Application, request),  RO, ":type: Request"},
   {"response", T_OBJECT_EX, offsetof(smisk_Application, response), RO, ":type: Response"},
   {"show_traceback", T_OBJECT_EX, offsetof(smisk_Application, show_traceback), 0, ":type: bool"},
-  {"memcached", T_OBJECT_EX, offsetof(smisk_Application, memcached), 0, ":type: string"},
   {"forks", T_INT, offsetof(smisk_Application, forks), 0, ":type: int"},
   {NULL, 0, 0, 0, NULL}
 };

--- a/src/Application.h
+++ b/src/Application.h
@@ -37,6 +37,7 @@ typedef struct {
   PyObject       *sessions; // lazy Session store
   
   PyObject       *show_traceback; // bool
+  PyObject       *memcached; // str
   int            forks; // int
   
   PyObject       *charset; // str

--- a/src/Application.h
+++ b/src/Application.h
@@ -37,7 +37,6 @@ typedef struct {
   PyObject       *sessions; // lazy Session store
   
   PyObject       *show_traceback; // bool
-  PyObject       *memcached; // str
   int            forks; // int
   
   PyObject       *charset; // str

--- a/src/FileSessionStore.c
+++ b/src/FileSessionStore.c
@@ -321,10 +321,16 @@ PyObject *smisk_FileSessionStore_write(smisk_FileSessionStore *self, PyObject *a
 PyDoc_STRVAR(smisk_FileSessionStore_refresh_DOC,
   ":param  session_id: Session ID\n"
   ":type   session_id: string\n"
+  ":param  data:       Data to be associated with ``session_id``\n"
+  ":type   data:       object\n"
   ":rtype: None");
-PyObject *smisk_FileSessionStore_refresh(smisk_FileSessionStore *self, PyObject *session_id) {
+PyObject *smisk_FileSessionStore_refresh(smisk_FileSessionStore *self, PyObject *args) {
   log_trace("ENTER");
   PyObject *fn;
+  PyObject *session_id;
+
+  if ( (session_id = PyTuple_GET_ITEM(args, 0)) == NULL )
+    return NULL;
   
   if ( (fn = smisk_FileSessionStore_path(self, session_id)) == NULL )
     return NULL;
@@ -381,7 +387,7 @@ PyDoc_STRVAR(smisk_FileSessionStore_DOC,
 static PyMethodDef smisk_FileSessionStore_methods[] = {
   {"read", (PyCFunction)smisk_FileSessionStore_read, METH_O, smisk_FileSessionStore_read_DOC},
   {"write", (PyCFunction)smisk_FileSessionStore_write, METH_VARARGS, smisk_FileSessionStore_write_DOC},
-  {"refresh", (PyCFunction)smisk_FileSessionStore_refresh, METH_O, smisk_FileSessionStore_refresh_DOC},
+  {"refresh", (PyCFunction)smisk_FileSessionStore_refresh, METH_VARARGS, smisk_FileSessionStore_refresh_DOC},
   {"destroy", (PyCFunction)smisk_FileSessionStore_destroy, METH_O, smisk_FileSessionStore_destroy_DOC},
   
   {"path", (PyCFunction)smisk_FileSessionStore_path, METH_O, smisk_FileSessionStore_path_DOC},

--- a/src/FileSessionStore.h
+++ b/src/FileSessionStore.h
@@ -36,7 +36,7 @@ extern PyTypeObject smisk_FileSessionStoreType;
 int smisk_FileSessionStore_register_types (PyObject *module);
 
 PyObject *smisk_FileSessionStore_new (PyTypeObject *type, PyObject *args, PyObject *kwds);
-PyObject *smisk_FileSessionStore_refresh (smisk_FileSessionStore *self, PyObject *session_id);
+PyObject *smisk_FileSessionStore_refresh (smisk_FileSessionStore *self, PyObject *args);
 PyObject *smisk_FileSessionStore_gc (smisk_FileSessionStore* self);
 
 #endif

--- a/src/MemcachedSessionStore.c
+++ b/src/MemcachedSessionStore.c
@@ -1,0 +1,220 @@
+/*
+Copyright (c) 2012 Emil Stenqvist
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#include "__init__.h"
+#include "utils.h"
+#include "file.h"
+#include "MemcachedSessionStore.h"
+
+/*
+ * DEVELOPER NOTES
+ *
+ * Memcached command reference:
+ * http://code.google.com/p/memcached/wiki/NewCommands
+ *
+ */
+
+#include <libmemcached/memcached.h>
+#include <pythread.h>
+
+#pragma mark Initialization & deallocation
+
+int smisk_MemcachedSessionStore_init(smisk_MemcachedSessionStore *self, PyObject *args, PyObject *kwargs) {  
+  log_trace("ENTER");
+  return 0;
+}
+
+
+void smisk_MemcachedSessionStore_dealloc(smisk_MemcachedSessionStore *self) {
+  log_trace("ENTER");
+  ((smisk_SessionStore *)self)->ob_type->tp_base->tp_dealloc((PyObject *)self);
+
+  log_debug("EXIT smisk_MemcachedSessionStore_dealloc");
+}
+
+#pragma mark -
+#pragma mark Methods
+
+
+PyDoc_STRVAR(smisk_MemcachedSessionStore_read_DOC,
+  ":param  session_id: Session ID\n"
+  ":type   session_id: string\n"
+  ":raises smisk.core.InvalidSessionError: if there is no actual session associated with ``session_id``.\n"
+  ":rtype: object");
+PyObject *smisk_MemcachedSessionStore_read(smisk_MemcachedSessionStore *self, PyObject *session_id) {
+  log_trace("ENTER");
+
+  PyObject *data = NULL, *key;
+
+  if ( !SMISK_STRING_CHECK(session_id) ) {
+    PyErr_SetString(PyExc_TypeError, "session_id must be a string");
+    return NULL;
+  }
+
+  // Find session
+  // key = ...;
+  if(NULL /* session was found */) {
+
+    // Read session
+    // Check ttl
+    // Put session data in "data"
+
+  } else {
+    log_debug("No session data.");
+    PyErr_SetString(smisk_InvalidSessionError, "no data");
+  }
+
+  return data;
+}
+
+
+PyDoc_STRVAR(smisk_MemcachedSessionStore_write_DOC,
+  ":param  session_id: Session ID\n"
+  ":type   session_id: string\n"
+  ":param  data:       Data to be associated with ``session_id``\n"
+  ":type   data:       object\n"
+  ":rtype: None");
+PyObject *smisk_MemcachedSessionStore_write(smisk_MemcachedSessionStore *self, PyObject *args) {
+  log_trace("ENTER");
+
+  PyObject *session_id, *data, *key;
+
+  if ( PyTuple_GET_SIZE(args) != 2 )
+    return PyErr_Format(PyExc_TypeError, "this method takes exactly 2 arguments");
+
+  if ( (session_id = PyTuple_GET_ITEM(args, 0)) == NULL )
+    return NULL;
+
+  if ( (data = PyTuple_GET_ITEM(args, 1)) == NULL )
+    return NULL;
+
+  if(NULL /* check if locked */) {
+    // We want to fail silently here, because another process go to the session before we did.
+    // Sorry, nothing we can do about it.
+    log_debug("smisk_file_lock failed - probably because another process has locked the session");
+  } else {
+    // Save session in memcached
+    log_debug("Wrote s");
+  }
+
+  Py_RETURN_NONE;
+}
+
+
+PyDoc_STRVAR(smisk_MemcachedSessionStore_refresh_DOC,
+  ":param  session_id: Session ID\n"
+  ":type   session_id: string\n"
+  ":rtype: None");
+PyObject *smisk_MemcachedSessionStore_refresh(smisk_MemcachedSessionStore *self, PyObject *session_id) {
+  log_trace("ENTER");
+
+  PyObject *key;
+  
+  /* if ( (key = smisk_FileSessionStore_path(self, session_id)) == NULL )*/
+    /* return NULL;*/
+
+  PyErr_SetString(PyExc_NotImplementedError, "refresh");
+  return NULL;
+}
+
+
+PyDoc_STRVAR(smisk_MemcachedSessionStore_destroy_DOC,
+  ":param  session_id: Session ID\n"
+  ":type   session_id: string\n"
+  ":rtype: None");
+PyObject *smisk_MemcachedSessionStore_destroy(smisk_MemcachedSessionStore *self, PyObject *session_id) {
+  log_trace("ENTER");
+  PyErr_SetString(PyExc_NotImplementedError, "destroy");
+  return NULL;
+}
+
+
+#pragma mark -
+#pragma mark Type construction
+
+PyDoc_STRVAR(smisk_MemcachedSessionStore_DOC,
+  "Basic session store type");
+
+// Methods
+static PyMethodDef smisk_MemcachedSessionStore_methods[] = {
+  {"read", (PyCFunction)smisk_MemcachedSessionStore_read, METH_O, smisk_MemcachedSessionStore_read_DOC},
+  {"write", (PyCFunction)smisk_MemcachedSessionStore_write, METH_VARARGS, smisk_MemcachedSessionStore_write_DOC},
+  {"refresh", (PyCFunction)smisk_MemcachedSessionStore_refresh, METH_O, smisk_MemcachedSessionStore_refresh_DOC},
+  {"destroy", (PyCFunction)smisk_MemcachedSessionStore_destroy, METH_O, smisk_MemcachedSessionStore_destroy_DOC},
+  {NULL, NULL, 0, NULL}
+};
+
+// Class members
+static struct PyMemberDef smisk_MemcachedSessionStore_members[] = {
+  {NULL, 0, 0, 0, NULL}
+};
+
+// Type definition
+PyTypeObject smisk_MemcachedSessionStoreType = {
+  PyObject_HEAD_INIT(&PyType_Type)
+  0,                         /*ob_size*/
+  "smisk.core.SessionStore",  /*tp_name*/
+  sizeof(smisk_MemcachedSessionStore), /*tp_basicsize*/
+  0,                         /*tp_itemsize*/
+  (destructor)smisk_MemcachedSessionStore_dealloc,        /* tp_dealloc */
+  0,                         /*tp_print*/
+  0,                         /*tp_getattr*/
+  0,                         /*tp_setattr*/
+  0,                         /*tp_compare*/
+  0,                         /*tp_repr*/
+  0,                         /*tp_as_number*/
+  0,                         /*tp_as_sequence*/
+  0,                         /*tp_as_mapping*/
+  0,                         /*tp_hash */
+  0,                         /*tp_call*/
+  0,                         /*tp_str*/
+  0,                         /*tp_getattro*/
+  0,                         /*tp_setattro*/
+  0,                         /*tp_as_buffer*/
+  Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE, /*tp_flags*/
+  smisk_MemcachedSessionStore_DOC,          /*tp_doc*/
+  (traverseproc)0,           /* tp_traverse */
+  0,                         /* tp_clear */
+  0,                         /* tp_richcompare */
+  0,                         /* tp_weaklistoffset */
+  0,                         /* tp_iter */
+  0,                         /* tp_iternext */
+  smisk_MemcachedSessionStore_methods, /* tp_methods */
+  smisk_MemcachedSessionStore_members, /* tp_members */
+  0,                              /* tp_getset */
+  0,                           /* tp_base */
+  0,                           /* tp_dict */
+  0,                           /* tp_descr_get */
+  0,                           /* tp_descr_set */
+  0,                           /* tp_dictoffset */
+  (initproc)smisk_MemcachedSessionStore_init, /* tp_init */
+  0,                           /* tp_alloc */
+  0,                           /* tp_new */
+  0                            /* tp_free */
+};
+
+int smisk_MemcachedSessionStore_register_types(PyObject *module) {
+  log_trace("ENTER");
+  smisk_MemcachedSessionStoreType.tp_base = &smisk_SessionStoreType;
+  if (PyType_Ready(&smisk_MemcachedSessionStoreType) == 0)
+    return PyModule_AddObject(module, "SessionStore", (PyObject *)&smisk_MemcachedSessionStoreType);
+  return -1;
+}

--- a/src/MemcachedSessionStore.c
+++ b/src/MemcachedSessionStore.c
@@ -33,12 +33,28 @@ THE SOFTWARE.
 #include <libmemcached/memcached.h>
 #include <pythread.h>
 
+#pragma mark Internal
+
+/* TODO: implement garbage collection code */
+
+static int _unlink(char *fn) {
+}
+
+static time_t _is_garbage(smisk_FileSessionStore *self, const char *fn, int fd) {
+  return false;
+}
+
+static int _gc_run(void *_self) {
+  return 0;
+}
+
 #pragma mark Initialization & deallocation
 
 int smisk_MemcachedSessionStore_init(smisk_MemcachedSessionStore *self, PyObject *args, PyObject *kwargs) {  
   log_trace("ENTER");
 
-  self->memcached_config = PyBytes_FromString("testing"); Py_INCREF(self->memcached_config);
+  self->memcached_config = PyBytes_FromString("");
+  Py_INCREF(self->memcached_config);
 
   return 0;
 }

--- a/src/MemcachedSessionStore.h
+++ b/src/MemcachedSessionStore.h
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2007-2009 Rasmus Andersson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#ifndef SMISK_MEMCACHED_SESSION_STORE_H
+#define SMISK_MEMCACHED_SESSION_STORE_H
+
+#include "SessionStore.h"
+
+typedef struct {
+  smisk_SessionStore parent;
+  
+  // Public Python & C
+} smisk_MemcachedSessionStore;
+
+
+extern PyTypeObject smisk_MemcachedSessionStoreType;
+
+int smisk_MemcachedSessionStore_register_types (PyObject *module);
+
+PyObject *smisk_MemcachedSessionStore_new (PyTypeObject *type, PyObject *args, PyObject *kwds);
+PyObject *smisk_MemcachedSessionStore_refresh (smisk_MemcachedSessionStore *self, PyObject *session_id);
+PyObject *smisk_MemcachedSessionStore_gc (smisk_MemcachedSessionStore* self);
+
+#endif

--- a/src/MemcachedSessionStore.h
+++ b/src/MemcachedSessionStore.h
@@ -23,13 +23,15 @@ THE SOFTWARE.
 #define SMISK_MEMCACHED_SESSION_STORE_H
 
 #include "SessionStore.h"
+#include <libmemcached/memcached.h>
 
 typedef struct {
   smisk_SessionStore parent;
-  
+  memcached_st   *memc;
+  PyObject       *memcached_config; // str
+
   // Public Python & C
 } smisk_MemcachedSessionStore;
-
 
 extern PyTypeObject smisk_MemcachedSessionStoreType;
 

--- a/src/MemcachedSessionStore.h
+++ b/src/MemcachedSessionStore.h
@@ -27,7 +27,6 @@ THE SOFTWARE.
 
 typedef struct {
   smisk_SessionStore parent;
-  memcached_st   *memc;
   PyObject       *memcached_config; // str
 
   // Public Python & C

--- a/src/MemcachedSessionStore.h
+++ b/src/MemcachedSessionStore.h
@@ -37,7 +37,7 @@ extern PyTypeObject smisk_MemcachedSessionStoreType;
 int smisk_MemcachedSessionStore_register_types (PyObject *module);
 
 PyObject *smisk_MemcachedSessionStore_new (PyTypeObject *type, PyObject *args, PyObject *kwds);
-PyObject *smisk_MemcachedSessionStore_refresh (smisk_MemcachedSessionStore *self, PyObject *session_id);
+PyObject *smisk_MemcachedSessionStore_refresh (smisk_MemcachedSessionStore *self, PyObject *args);
 PyObject *smisk_MemcachedSessionStore_gc (smisk_MemcachedSessionStore* self);
 
 #endif

--- a/src/Request.c
+++ b/src/Request.c
@@ -251,7 +251,7 @@ static int _cleanup_session(smisk_Request* self) {
     }
     else if (self->initial_session_hash == h) {
       // Session data was unchanged. Give the session store the opportunity to refresh this sessions' TTL:
-      if ( (ro = PyObject_CallMethod(smisk_Application_current->sessions, "refresh", "O", self->session_id)) == NULL )
+      if ( (ro = PyObject_CallMethod(smisk_Application_current->sessions, "refresh", "OO", self->session_id, self->session)) == NULL )
         return -1;
       Py_DECREF(ro);
     }

--- a/src/SessionStore.c
+++ b/src/SessionStore.c
@@ -84,8 +84,10 @@ PyObject *smisk_SessionStore_write(smisk_SessionStore *self, PyObject *args) {
 PyDoc_STRVAR(smisk_SessionStore_refresh_DOC,
   ":param  session_id: Session ID\n"
   ":type   session_id: string\n"
+  ":param  data:       Data to be associated with ``session_id``\n"
+  ":type   data:       object\n"
   ":rtype: None");
-PyObject *smisk_SessionStore_refresh(smisk_SessionStore *self, PyObject *session_id) {
+PyObject *smisk_SessionStore_refresh(smisk_SessionStore *self, PyObject *args) {
   log_trace("ENTER");
   PyErr_SetString(PyExc_NotImplementedError, "refresh");
   return NULL;
@@ -113,7 +115,7 @@ PyDoc_STRVAR(smisk_SessionStore_DOC,
 static PyMethodDef smisk_SessionStore_methods[] = {
   {"read", (PyCFunction)smisk_SessionStore_read, METH_O, smisk_SessionStore_read_DOC},
   {"write", (PyCFunction)smisk_SessionStore_write, METH_VARARGS, smisk_SessionStore_write_DOC},
-  {"refresh", (PyCFunction)smisk_SessionStore_refresh, METH_O, smisk_SessionStore_refresh_DOC},
+  {"refresh", (PyCFunction)smisk_SessionStore_refresh, METH_VARARGS, smisk_SessionStore_refresh_DOC},
   {"destroy", (PyCFunction)smisk_SessionStore_destroy, METH_O, smisk_SessionStore_destroy_DOC},
   {NULL, NULL, 0, NULL}
 };

--- a/src/__init__.c
+++ b/src/__init__.c
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "URL.h"
 #include "SessionStore.h"
 #include "FileSessionStore.h"
+#include "MemcachedSessionStore.h"
 #include "xml/__init__.h"
 #include "crash_dump.h"
 
@@ -307,6 +308,7 @@ PyMODINIT_FUNC  PyInit__smisk(void)    /* Note the two underscores */
   R(URL_register_types, != 0);
   R(SessionStore_register_types, != 0);
   R(FileSessionStore_register_types, != 0);
+  R(MemcachedSessionStore_register_types, != 0);
   R(xml_register, == NULL);
   #undef R
   


### PR DESCRIPTION
Hey

I've started working on a `MemcachedSessionStore` for smisk as an alternative to the `FileSessionStore` that can be shared by multiple instances of smisk, not running on the same machine.

Note that this is not ready to be pulled into the master repo, but I just wanted to give you a heads up and possibly get some input.

The commit concerning the uid generation uid.c can be ignored - for some reason I get a buffer overflow when running sha1_final() on my Mac OS system. I haven't put any effort into fixing this, and so just replaced it with a silly "id generation". I can give you more details on this if you wish!

Right now what remains is:
- See if there's a nicer way to run `refresh()` without fetching the session from the memcached server, maybe an API change that passes `data` to the `refresh()` function as is done for `write()`.
- Make this an optional `SessionStore` - right now I've hardcoded it - just like was done for FileSessionStore previously. Any pointers on how this should be done?
- Garbage collection code
- Check INCREF/DECREF in the code - this is my first take with the Python C API so I've been pretty sloppy with the reference counting
- Make sure that `memcached_string` is read from a config parameter

Oh, and to be able to deploy this in production I've based it on the v1.1.6 tag, but it should be easily merged into master.

Mvh
Emil
